### PR TITLE
Added filter call to determine if a level is a trial or not.

### DIFF
--- a/pmpro-kissmetrics.php
+++ b/pmpro-kissmetrics.php
@@ -153,7 +153,12 @@ function pmprokm_after_checkout($user_id) {
     }
 
     //if level contains trial, track trial as well
-    if($level->trial_limit > 0 && !empty($pmprokm_options['track_pmpro_trials']))
+    
+    // Because trial can mean different things to different systems, let's give
+    // some flexibility through a filter. Default is that it's a trial if trial_limit>0.
+    $is_trial = apply_filters('pmprokm_is_trial', $level->trial_limit > 0, $level);
+    
+    if($is_trial && !empty($pmprokm_options['track_pmpro_trials']))
         KM::record('Started Trial');
 }
 add_action('pmpro_after_checkout', 'pmprokm_after_checkout');


### PR DESCRIPTION
Added a filter, pmprokm_is_trial, to give flexibility in determining if
a level is a trial. Set the default to be how it was calc’ed before
(trial_limit>0), and added some explanatory comments.
