### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-kissmetrics.php
+++ b/pmpro-kissmetrics.php
@@ -139,7 +139,7 @@ function pmprokm_template_redirect() {
 
         //include selected level if we're on che checkout page
         if($post->ID == $pmpro_pages['checkout']) {
-            $level = pmpro_getLevel($_REQUEST['level']);
+            $level  = pmpro_getLevelAtCheckout();
             $event .= ' (' . $level->name . ')';
         }
 


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.